### PR TITLE
add logging (should close #7)

### DIFF
--- a/src/halodrops/__init__.py
+++ b/src/halodrops/__init__.py
@@ -1,0 +1,28 @@
+import logging
+
+# create halodrops logger
+logger = logging.getLogger("halodrops")
+logger.setLevel(logging.DEBUG)
+
+# File Handler
+fh_info = logging.FileHandler("info.log")
+fh_info.setLevel(logging.INFO)
+
+fh_debug = logging.FileHandler("debug.log", mode="w")
+fh_debug.setLevel(logging.DEBUG)
+
+# Console handler
+ch = logging.StreamHandler()
+ch.setLevel(logging.WARNING)
+
+# Formatter
+log_format = "{asctime}  {levelname:^8s} {name:^20s} {filename:^20s} Line:{lineno:03d}:\n{message}"
+formatter = logging.Formatter(log_format, style="{")
+fh_info.setFormatter(formatter)
+fh_debug.setFormatter(formatter)
+ch.setFormatter(formatter)
+
+# Add file and streams handlers to the logger
+logger.addHandler(fh_info)
+logger.addHandler(fh_debug)
+logger.addHandler(ch)

--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -7,14 +7,19 @@ import os.path
 from halodrops.helper import rawreader as rr
 from halodrops.sonde import Sonde
 
+# create logger
+module_logger = logging.getLogger("halodrops.helper.paths")
+
+
 class Paths:
     """
     Deriving paths from the provided directory
 
-    The input should align in terms of hierarchy and nomenclature 
+    The input should align in terms of hierarchy and nomenclature
     with the {doc}`Directory Structure </handbook/directory_structure>` that `halodrops` expects.
     """
-    def __init__(self,directory,flightdir):
+
+    def __init__(self, directory, flightdir):
         """Creates an instance of Paths object for a given flight
 
         Parameters
@@ -36,24 +41,27 @@ class Paths:
         `l1dir`
             Path to Level-1 data directory
         """
-        self.flightdir = os.path.join(directory,flightdir)
+        self.logger = logging.getLogger("halodrops.helper.paths.Paths")
+        self.flightdir = os.path.join(directory, flightdir)
         self.flightdirname = flightdir
-        self.l0dir = os.path.join(directory,flightdir,'Level_0')
-        self.l1dir = os.path.join(directory,flightdir,'Level_1')
+        self.l0dir = os.path.join(directory, flightdir, "Level_0")
+        self.l1dir = os.path.join(directory, flightdir, "Level_1")
 
-        logging.info(f'Created Path Instance: {self.flightdir=}; {self.flightdirname=}; {self.l1dir=}')
+        self.logger.info(
+            f"Created Path Instance: {self.flightdir=}; {self.flightdirname=}; {self.l1dir=}"
+        )
 
     def get_all_afiles(self):
         """Returns a list of paths to all A-files for the given directory
         and also sets it as attribute named 'afiles_list'
         """
-        a_files = glob.glob(os.path.join(self.l0dir,'A*'))
+        a_files = glob.glob(os.path.join(self.l0dir, "A*"))
         self.afiles_list = a_files
         return a_files
 
     def quicklooks_path(self):
         """Path to quicklooks directory
-        
+
         Function checks for an existing quicklooks directory, and if not found, creates one.
 
         Returns
@@ -61,12 +69,14 @@ class Paths:
         `str`
             Path to quicklooks directory
         """
-        quicklooks_path_str = os.path.join(self.flightdir,'Quicklooks')
+        quicklooks_path_str = os.path.join(self.flightdir, "Quicklooks")
         if pp(quicklooks_path_str).exists():
-            logging.info(f'Path exists: {quicklooks_path_str=}')
-        else:    
+            self.logger.info(f"Path exists: {quicklooks_path_str=}")
+        else:
             pp(quicklooks_path_str).mkdir(parents=True)
-            logging.info(f'Path did not exist. Created directory: {quicklooks_path_str=}')
+            self.logger.info(
+                f"Path did not exist. Created directory: {quicklooks_path_str=}"
+            )
         return quicklooks_path_str
 
     def populate_sonde_instances(self) -> Dict:
@@ -82,12 +92,12 @@ class Paths:
             sonde_id = rr.get_sonde_id(a_file)
             launch_time = rr.get_launch_time(a_file)
 
-            Sondes[sonde_id] = Sonde(sonde_id,launch_time=launch_time)
+            Sondes[sonde_id] = Sonde(sonde_id, launch_time=launch_time)
             Sondes[sonde_id].add_launch_detect(launch_detect)
             Sondes[sonde_id].add_afile(a_file)
             Sondes[sonde_id].add_postaspenfile()
             Sondes[sonde_id].add_aspen_ds()
 
-        object.__setattr__(self, 'Sondes', Sondes)
-        
+        object.__setattr__(self, "Sondes", Sondes)
+
         return Sondes


### PR DESCRIPTION
**Central logging init**

Logging in HALO-DROPS is initialized at a single point: the `__init__` file in the `halodrops` directory within the `src` directory. This means that the first import of any module of the `halodrops` package gets the `halodrops` logger. The idea then is that the modules called from the package should be handled by this logger.

**Logging by modules & entities therein**

We make use of the inbuilt facility of the `logging` module that [any logger with a point in its name technically has a child-parent relationship](https://docs.python.org/3/library/logging.html#logger-objects), i.e. any thing preceding the point is a parent, and that succeeding the point is a child. Therefore, all modules have their logger in the form of `halodrops.hierarchical.path.module`. For example, the `paths` module in the `helper` module has its logger called `halodrops.helper.paths`.

Usually, functions can simply log to their module logger. For classes, however, it is convenient to also have their own logger. Here, we again exploit the parent-child logging relation simply by appending the name of the class at the end. For example, the `Paths` class in the module we referenced above would have a logger `halodrops.helper.paths.Paths`.

**Outputting logs**

The `halodrops` logger and all its children are set to output their logs to three different handlers - two FileHandlers and one StreamHandler. They are differentiated as follows:

| Handler           | Type          | Logging Level | File mode |
| ----------------- | ------------- | ------------- | --------- |
| To file info.log  | FileHandler   | INFO          | append    |
| To file debug.log | FileHandler   | DEBUG         | write     |
| To console        | StreamHandler | WARNING       | write     |

The formatting is the same for all three handlers, i.e. `"{asctime}  {levelname:^8s} {name:^20s} {filename:^20s} Line:{lineno:03d}:\n{message}"`