### PR TITLE
add check for docstring in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,16 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1
+    hooks:
+    -   id: pydocstyle
+        args:
+        - --convention=numpy
+-   repo: https://github.com/econchick/interrogate
+    rev: 1.5.0
+    hooks:
+    -   id: interrogate
+        args:
+        - --fail-under=90
+        - --verbose


### PR DESCRIPTION
- add the [pydocstyle hook](http://www.pydocstyle.org/en/stable/) to pre-commit, where I have set the check for docstrings to be in the `numpy` convention. The other available options were `google` and `pep257`, but `numpy` just seemed really nice to me. See also [the example they show](https://numpydoc.readthedocs.io/en/latest/example.html#example).
- add the [interrogate hook](https://interrogate.readthedocs.io/en/latest/) to pre-commit to check the coverage of documentation wrt docstrings. It is currently set to fail if under 90% of all objects are missing docstrings.