### PR TITLE
add framework for integrating config

### DIFF
--- a/halodrops.cfg
+++ b/halodrops.cfg
@@ -1,0 +1,2 @@
+[PATHS]
+data-directory = "./Data/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "Geet George", email = "geet.george@mpimet.mpg.de"}]
 
+[project.scripts]
+halodrops = "halodrops.__init__:main"
+
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",

--- a/src/halodrops/__init__.py
+++ b/src/halodrops/__init__.py
@@ -26,3 +26,34 @@ ch.setFormatter(formatter)
 logger.addHandler(fh_info)
 logger.addHandler(fh_debug)
 logger.addHandler(ch)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser("Arguments")
+
+    parser.add_argument(
+        "-c",
+        "--configpath",
+        default="./halodrops.cfg",
+        help="config file path for halodrops, by default the config file is halodrops.cfg in the current directory",
+    )
+
+    args = parser.parse_args()
+    import os
+
+    if args.configpath[-3:] != "cfg":
+        config_path = os.path.join(args.configpath, "halodrops.cfg")
+    else:
+        config_path = args.configpath
+
+    if os.path.exists(config_path):
+        import configparser
+
+        config = configparser.ConfigParser()
+        config.read(config_path)
+    else:
+        return print(
+            f"{config_path}: Path does not exist. Please check config file location."
+        )


### PR DESCRIPTION
The idea with this commit is to allow the user to interact with halodrops only via a configuration file.

By default this file is located in the directory where the user runs `halodrops` from and is called `halodrops.cfg`. Here the file only has the data directory field, enough to test out if the framework works.

This commit sets the framework for the user to provide a path to the config file as an argument in the command line, with the argument option `--configpath` or `-c`. This is done by using the function `main`. An example of using is

```
halodrops -c="../myconfigdirectory/ac3_configuration.cfg"
```

To get the `halodrops` command working, this main function is provided as an entry point in the TOML file.

**Afterthought...**

Now, calls to other scripts should work by just adding them to the main function. Ideally, other scripts will not interact with the config file. It will be the job of the `main` function to provide inputs to the other scripts by reading the config. This might mean nesting other functions in `main`, or more functions in `__init__.py`. More arguments could also be provided for the user to call only certain scripts. Or this could be set up via the config file too. The latter is the better option because when sharing data, only the version of `halodrops` and the config file is needed. The arguments to calling `halodrops` are not really stored anywhere automatically.