### PR TITLE
Add Inspect function

### DIFF
--- a/docs/source/explanation/for_developers.md
+++ b/docs/source/explanation/for_developers.md
@@ -1,0 +1,52 @@
+# For Developers
+
+## How does `halodrops.__init__` work?
+
+The idea is to minimize the decision-making on the user's part. The user should be able to run the package with minimal configuration. The package should be able to handle the rest. For this, all functions in the package should ideally have all arguments with default values. The user can override these default values by providing non-default values in a configuration file. 
+
+However, some arguments cannot have default values (e.g. `data_directory` or `flight_id`). These arguments are mandatory and must be provided by the user within a `MANDATORY` section in the configuration file. This means that functions in the package that have the same mandatory arguments must always use the same argument name across the whole package (e.g. `data_directory` should not be called by a different function as `data_dir`).
+
+The package handles these non-default and mandatory values and executes the functions with the provided arguments.
+
+This `__init__` script thus retrieves mandatory and non-default values from the configuration file for functions within the package and its subpackages, and executes those functions with the retrieved arguments.
+
+### Functions
+`__init__` defines several functions:
+
+`get_all_defaults(package)`: This function retrieves the default values of all functions within a package and its subpackages. It returns a dictionary where the keys are the fully qualified names of the functions, and the values are dictionaries containing the default values of the function parameters.
+
+`nondefault_values_from_config(config, default_dict)`: This function retrieves non-default argument values from a configuration file. It returns a dictionary containing the non-default arguments and their corresponding values based on the config file.
+
+`get_mandatory_args(function)`: This function retrieves a list of all arguments that do not have a default value for a given function.
+
+`get_mandatory_values_from_config(config, mandatory_args)`: This function extracts mandatory values from the 'MANDATORY' section of a configuration file. It returns a dictionary where the keys are the argument names and the values are the corresponding values from the config file.
+
+### Main Execution
+The script's main execution begins by parsing command-line arguments to get the path to a configuration file. It then checks if the provided directory and file exist. If they do, it reads the configuration file.
+
+Next, it retrieves the default values for all functions within the halodrops package using the `get_all_defaults` function. It then retrieves the non-default values from the configuration file using the `nondefault_values_from_config` function.
+
+The script then defines a list of functions to execute. For each function, it retrieves the non-default arguments from the previously retrieved non-default values. If the function has mandatory arguments, it retrieves their values from the configuration file using the `get_mandatory_values_from_config` function.
+
+Finally, the script executes each function with the retrieved arguments.
+
+### Usage
+To use this script, you need to provide a configuration file that contains the non-default and mandatory values for the functions you want to execute. The configuration file should should have a `MANDATORY` section and a separate for each function where non-default values are to be provided, where the section name is the fully qualified name of the function (e.g.`api.qc.run`). Each section should contain options for the function arguments, where the option names are the argument names and the option values are the argument values.
+
+An example config file would look like
+
+```ini
+[MANDATORY]
+data_directory = /path/to/data
+flight_id = 20220401
+
+[api.qc.run]
+arg1 = nondefault1
+arg2 = nondefault2
+```
+
+You can run the script from the command line simply by running `halodrops` or optionally with the `-c` or `--config_file_path` option followed by the path to your configuration file. For example:
+
+```bash
+halodrops -c /path/to/config/file
+```

--- a/docs/source/explanation/for_developers.md
+++ b/docs/source/explanation/for_developers.md
@@ -2,7 +2,7 @@
 
 ## How does `halodrops.__init__` work?
 
-The idea is to minimize the decision-making on the user's part. The user should be able to run the package with minimal configuration. The package should be able to handle the rest. For this, all functions in the package should ideally have all arguments with default values. The user can override these default values by providing non-default values in a configuration file. 
+The idea is to minimize the decision-making on the user's part. The user should be able to run the package with minimal configuration. The package should be able to handle the rest. For this, all functions in the package should ideally have all arguments with default values. The user can override these default values by providing non-default values in a configuration file.
 
 However, some arguments cannot have default values (e.g. `data_directory` or `flight_id`). These arguments are mandatory and must be provided by the user within a `MANDATORY` section in the configuration file. This means that functions in the package that have the same mandatory arguments must always use the same argument name across the whole package (e.g. `data_directory` should not be called by a different function as `data_dir`).
 

--- a/docs/source/explanation/index.md
+++ b/docs/source/explanation/index.md
@@ -6,4 +6,5 @@
 
 performance_of_sondes
 reconditioning
+for_developers
 ```

--- a/halodrops.cfg
+++ b/halodrops.cfg
@@ -1,9 +1,5 @@
 [MANDATORY]
-data_directory = ./sample/
-flight_id = None
-
-[api.qc.run]
-data_directory = ./sample/
+data_directory = /Users/geetgeorge/Documents/Work/Research/Projects/Pre-TUD/AC3/Dropsondes/Data/Data
 flight_id = 20220401
 
 [api.qc.run2]

--- a/halodrops.cfg
+++ b/halodrops.cfg
@@ -1,2 +1,11 @@
-[PATHS]
-data-directory = "./Data/"
+[MANDATORY]
+data_directory = ./sample/
+flight_id = None
+
+[api.qc.run]
+data_directory = ./sample/
+flight_id = 20220401
+
+[api.qc.run2]
+arg1 = nondefault1
+arg2 = nondefault2

--- a/src/halodrops/__init__.py
+++ b/src/halodrops/__init__.py
@@ -118,6 +118,7 @@ def nondefault_values_from_config(config, default_dict):
 
     return function_defaults
 
+
 def get_mandatory_args(function):
     """
     Get a list of all arguments that do not have a default value for each function in the list.
@@ -145,9 +146,9 @@ def get_mandatory_args(function):
     sig = inspect.signature(function)
     for name, param in sig.parameters.items():
         if param.default == inspect.Parameter.empty:
-            mandatory_args.append(name) 
+            mandatory_args.append(name)
     return mandatory_args
-    
+
 
 def get_mandatory_values_from_config(config, mandatory_args):
     """
@@ -178,16 +179,17 @@ def get_mandatory_values_from_config(config, mandatory_args):
     >>> mandatory_values_from_config(config, ['arg1', 'arg2'])
     {'arg1': 'value1', 'arg2': 'value2'}
     """
-    if not config.has_section('MANDATORY'):
-        raise ValueError(f'MANDATORY section not found in config file')
+    if not config.has_section("MANDATORY"):
+        raise ValueError(f"MANDATORY section not found in config file")
     else:
         mandatory_dict = {}
         for arg in mandatory_args:
-            if config.has_option('MANDATORY', arg):
-                mandatory_dict[arg] = config.get('MANDATORY', arg)
+            if config.has_option("MANDATORY", arg):
+                mandatory_dict[arg] = config.get("MANDATORY", arg)
             else:
-                raise ValueError(f'Mandatory argument {arg} not found in config file')
+                raise ValueError(f"Mandatory argument {arg} not found in config file")
     return mandatory_dict
+
 
 def main():
     import argparse
@@ -240,10 +242,10 @@ def main():
             nondefault_args = nondefaults[section_name]
         else:
             nondefault_args = {}
-    
+
         mandatory = get_mandatory_args(function)
         if mandatory:
             mandatory_args = get_mandatory_values_from_config(config, mandatory)
             nondefault_args.update(mandatory_args)
-        
+
         function(**nondefault_args)

--- a/src/halodrops/api/qc.py
+++ b/src/halodrops/api/qc.py
@@ -1,0 +1,18 @@
+# from halodrops import sonde
+from halodrops.helper import paths
+from halodrops.qc import profile
+
+
+def run(data_directory="default", flight_id="20220401"):
+    paths_for_flight = paths.Paths(data_directory, flight_id)
+    # Create Sondes dictionary
+    Sondes = paths_for_flight.populate_sonde_instances()
+    ds = Sondes[list(Sondes.keys())[10]].aspen_ds
+    var = "tdry"
+    return print(
+        f"---------------------\n For Sonde {list(Sondes.keys())[10]} the {var} variable has a weighted profile fullness of {profile.weighted_fullness(ds,var,sampling_frequency=2):.02f}. Yay!"
+    )
+
+
+def run2(arg1="default1", arg2="default2"):
+    return print(f"{arg1=} & {arg2=}")

--- a/src/halodrops/api/qc.py
+++ b/src/halodrops/api/qc.py
@@ -3,14 +3,15 @@ from halodrops.helper import paths
 from halodrops.qc import profile
 
 
-def run(data_directory="default", flight_id="20220401"):
+def run(data_directory, flight_id):
     paths_for_flight = paths.Paths(data_directory, flight_id)
     # Create Sondes dictionary
     Sondes = paths_for_flight.populate_sonde_instances()
-    ds = Sondes[list(Sondes.keys())[10]].aspen_ds
+    [print(f"{i}: {Sondes[i].launch_detect}") for i in list(Sondes.keys())]
+    ds = Sondes[list(Sondes.keys())[1]].aspen_ds
     var = "tdry"
     return print(
-        f"---------------------\n For Sonde {list(Sondes.keys())[10]} the {var} variable has a weighted profile fullness of {profile.weighted_fullness(ds,var,sampling_frequency=2):.02f}. Yay!"
+        f"---------------------\n For Sonde {list(Sondes.keys())[1]} the {var} variable has a weighted profile fullness of {profile.weighted_fullness(ds,var,sampling_frequency=2):.02f}. Yay!"
     )
 
 

--- a/tests/test_inspect_function.py
+++ b/tests/test_inspect_function.py
@@ -1,6 +1,6 @@
 from configparser import ConfigParser
 from typing import Dict
-from halodrops import nondefault_values_from_config
+from halodrops import nondefault_values_from_config,get_mandatory_args, get_mandatory_values_from_config
 import pytest
 
 
@@ -134,3 +134,53 @@ def test_nondefault_values_from_config_with_empty_config(
     result = nondefault_values_from_config(empty_config, default_dict)
 
     assert result == {}
+
+
+def test_get_mandatory_args():
+    """
+    Test get_mandatory_args function.
+    """
+    def sample_function(arg1, arg2, arg3='default'):
+        pass
+
+    result = get_mandatory_args(sample_function)
+    assert result == ['arg1', 'arg2']
+
+
+def test_get_mandatory_values_from_config():
+    """
+    Test get_mandatory_values_from_config function.
+    """
+    mandatory_args = ['arg1', 'arg2']
+    config = ConfigParser()
+    config.add_section("MANDATORY")
+    config.set("MANDATORY", "arg1", "value1")
+    config.set("MANDATORY", "arg2", "value2")
+
+    result = get_mandatory_values_from_config(config, mandatory_args)
+    assert result == {'arg1': 'value1', 'arg2': 'value2'}
+
+
+def test_get_mandatory_values_from_config_missing_section():
+    """
+    Test get_mandatory_values_from_config function with missing MANDATORY section.
+    """
+    mandatory_args = ['arg1', 'arg2']
+    config = ConfigParser()
+
+    with pytest.raises(ValueError, match='MANDATORY section not found in config file'):
+        get_mandatory_values_from_config(config, mandatory_args)
+
+
+def test_get_mandatory_values_from_config_missing_arg():
+    """
+    Test get_mandatory_values_from_config function with missing mandatory argument.
+    """
+    mandatory_args = ['arg1', 'arg2', 'arg3']
+    config = ConfigParser()
+    config.add_section("MANDATORY")
+    config.set("MANDATORY", "arg1", "value1")
+    config.set("MANDATORY", "arg2", "value2")
+
+    with pytest.raises(ValueError, match='Mandatory argument arg3 not found in config file'):
+        get_mandatory_values_from_config(config, mandatory_args)

--- a/tests/test_inspect_function.py
+++ b/tests/test_inspect_function.py
@@ -1,6 +1,10 @@
 from configparser import ConfigParser
 from typing import Dict
-from halodrops import nondefault_values_from_config,get_mandatory_args, get_mandatory_values_from_config
+from halodrops import (
+    nondefault_values_from_config,
+    get_mandatory_args,
+    get_mandatory_values_from_config,
+)
 import pytest
 
 
@@ -140,35 +144,36 @@ def test_get_mandatory_args():
     """
     Test get_mandatory_args function.
     """
-    def sample_function(arg1, arg2, arg3='default'):
+
+    def sample_function(arg1, arg2, arg3="default"):
         pass
 
     result = get_mandatory_args(sample_function)
-    assert result == ['arg1', 'arg2']
+    assert result == ["arg1", "arg2"]
 
 
 def test_get_mandatory_values_from_config():
     """
     Test get_mandatory_values_from_config function.
     """
-    mandatory_args = ['arg1', 'arg2']
+    mandatory_args = ["arg1", "arg2"]
     config = ConfigParser()
     config.add_section("MANDATORY")
     config.set("MANDATORY", "arg1", "value1")
     config.set("MANDATORY", "arg2", "value2")
 
     result = get_mandatory_values_from_config(config, mandatory_args)
-    assert result == {'arg1': 'value1', 'arg2': 'value2'}
+    assert result == {"arg1": "value1", "arg2": "value2"}
 
 
 def test_get_mandatory_values_from_config_missing_section():
     """
     Test get_mandatory_values_from_config function with missing MANDATORY section.
     """
-    mandatory_args = ['arg1', 'arg2']
+    mandatory_args = ["arg1", "arg2"]
     config = ConfigParser()
 
-    with pytest.raises(ValueError, match='MANDATORY section not found in config file'):
+    with pytest.raises(ValueError, match="MANDATORY section not found in config file"):
         get_mandatory_values_from_config(config, mandatory_args)
 
 
@@ -176,11 +181,13 @@ def test_get_mandatory_values_from_config_missing_arg():
     """
     Test get_mandatory_values_from_config function with missing mandatory argument.
     """
-    mandatory_args = ['arg1', 'arg2', 'arg3']
+    mandatory_args = ["arg1", "arg2", "arg3"]
     config = ConfigParser()
     config.add_section("MANDATORY")
     config.set("MANDATORY", "arg1", "value1")
     config.set("MANDATORY", "arg2", "value2")
 
-    with pytest.raises(ValueError, match='Mandatory argument arg3 not found in config file'):
+    with pytest.raises(
+        ValueError, match="Mandatory argument arg3 not found in config file"
+    ):
         get_mandatory_values_from_config(config, mandatory_args)

--- a/tests/test_inspect_function.py
+++ b/tests/test_inspect_function.py
@@ -1,0 +1,136 @@
+from configparser import ConfigParser
+from typing import Dict
+from halodrops import nondefault_values_from_config
+import pytest
+
+
+@pytest.fixture
+def sample_config() -> ConfigParser:
+    """
+    Fixture for creating a sample config object with test values.
+
+    Returns:
+        ConfigParser: A sample config object.
+    """
+    config = ConfigParser()
+    config.add_section("function1")
+    config.set("function1", "arg1", "value1")
+    config.set("function1", "arg2", "value2")
+    config.add_section("function2")
+    config.set("function2", "arg1", "value3")
+    config.add_section("function_not_in_default_dict")
+    config.set("function_not_in_default_dict", "arg1", "value4")
+    config.add_section("function_with_empty_section_in_config")
+    return config
+
+
+@pytest.fixture
+def default_dict() -> Dict[str, Dict[str, str]]:
+    """
+    Fixture for creating a sample default dictionary.
+
+    Returns:
+        dict: A sample default dictionary.
+    """
+    return {
+        "function1": {"arg1": "default1", "arg2": "default2"},
+        "function2": {"arg1": "default3"},
+        "function_with_empty_section_in_config": {
+            "arg1": "default4",
+            "arg2": "default5",
+        },
+    }
+
+
+def test_nondefault_values_from_config_with_sample_config(
+    sample_config: ConfigParser, default_dict: Dict[str, Dict[str, str]]
+) -> None:
+    """
+    Test nondefault_values_from_config with a sample config object and default dictionary.
+
+    Test the behavior of the nondefault_values_from_config function when provided with a sample
+    config object and default dictionary. It checks if the function correctly identifies the
+    non-default values in the config object based on the default dictionary.
+
+    Parameters:
+        sample_config (ConfigParser): A sample config object with test values.
+        default_dict (dict): A sample default dictionary.
+
+    Returns:
+        None
+    """
+    result = nondefault_values_from_config(sample_config, default_dict)
+
+    expected_result = {
+        "function1": {"arg1": "value1", "arg2": "value2"},
+        "function2": {"arg1": "value3"},
+    }
+    assert result == expected_result
+
+
+def test_nondefault_values_from_config_with_section_missing_in_default_dict(
+    sample_config: ConfigParser, default_dict: Dict[str, Dict[str, str]]
+) -> None:
+    """
+    Test nondefault_values_from_config with a missing section in the default dictionary.
+
+    Test the behavior of the nondefault_values_from_config function when provided with a sample
+    config object and a default dictionary that is missing a section. It checks if the function
+    correctly handles the case where a section is present in the config object but not in the
+    default dictionary.
+
+    Parameters:
+        sample_config (ConfigParser): A sample config object with test values.
+        default_dict (dict): A sample default dictionary.
+
+    Returns:
+        None
+    """
+    result = nondefault_values_from_config(sample_config, default_dict)
+
+    assert "function_not_in_default_dict" not in result
+
+
+def test_nondefault_values_from_config_with_section_having_no_arguments(
+    sample_config: ConfigParser, default_dict: Dict[str, Dict[str, str]]
+) -> None:
+    """
+    Test nondefault_values_from_config with missing arguments in the config file.
+
+    Test the behavior of the nondefault_values_from_config function when provided with a sample
+    config object and a default dictionary that is missing arguments. It checks if the function
+    correctly handles the case where a section is present in the config object, and the default
+    dictionary contains the section, but some arguments are missing in the config.
+
+    Parameters:
+        sample_config (ConfigParser): A sample config object with test values.
+        default_dict (dict): A sample default dictionary.
+
+    Returns:
+        None
+    """
+    result = nondefault_values_from_config(sample_config, default_dict)
+
+    assert "function_with_empty_section_in_config" not in result
+
+
+def test_nondefault_values_from_config_with_empty_config(
+    default_dict: Dict[str, Dict[str, str]]
+) -> None:
+    """
+    Test nondefault_values_from_config with an empty config object.
+
+    Test the behavior of the nondefault_values_from_config function when provided with an empty
+    config object and a default dictionary. It checks if the function correctly handles the case
+    where the config object is empty and returns an empty dictionary.
+
+    Parameters:
+        default_dict (dict): A sample default dictionary.
+
+    Returns:
+        None
+    """
+    empty_config = ConfigParser()
+    result = nondefault_values_from_config(empty_config, default_dict)
+
+    assert result == {}


### PR DESCRIPTION
This PR adds:

(i) an inspect function (called `get_all_defaults`) which goes through all modules & submodules and all functions inside each of them. It returns a dictionary with keys as function names with all parent modules (`module.submodule.submodule.function`) and values as another dictionary. This nested dictionary has keys that are argument names of the function and values are the default values of the respective arguments.

(ii) a function called `nondefault_values_from_config` which reads from a provided config file and compares with a provided dictionary full of default arguments. It checks for any differences between the two and returns a dictionary with only the non-default args from the config.

(iii) some template functions in `api/qc.py` and corresponding changes to the `main` function to show how this framework will work.

(iv) tests to check the inspect function and reading the non-default values

## [`handle mandatory args with config`](https://github.com/Geet-George/halodrops/pull/35/commits/9628e95de10fd312decb12aa3fb47ebbf0efcc36)

This commit introduces changes to the way functions can have arguments with non-default values, which can be obtained when the configuration file is parsed.
Previously, the code only considered arguments with default values. Now, it also handles mandatory arguments that do not have default values.

The changes include:

1. Adding the function `get_mandatory_args(function)`: This function inspects a given function and returns a list of all argument names that do not have a default value. This is useful for identifying which arguments are mandatory when calling a function.

2. Adding the function `get_mandatory_values_from_config(config, mandatory_args)`: This function extracts values for a given list of mandatory arguments from the 'MANDATORY' section of a provided configuration file. It returns a dictionary where the keys are the given argument names and the values are the corresponding values from the config file. If the 'MANDATORY' section is not found in the config file or if a mandatory argument is not found in the 'MANDATORY' section, it raises a ValueError.

3. In the main function, after parsing the arguments, the code now checks if the list of mandatory arguments is non-empty. If it is, it gets the mandatory values from the config file and updates the `nondefaults` dictionary with these values.

These changes ensure that all necessary arguments (both with and without default values) are provided before the functions are run.

## [`add docs for devs about how init works`](https://github.com/Geet-George/halodrops/pull/35/commits/86ee3cee98fd3f3496cc42e4ddac373e1c9e787b)

- Documentation added (particularly keeping in mind developers) to explain how the `__init__` works by checking for non-default and mandatory values 
- Also include there the idea behind why we do this and a usage example.