### PR TITLE
add pre-commit ci with all defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,5 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
+ci:
+    autofix_prs: true


### PR DESCRIPTION
Setting up pre-commit ci to not bother humans with re-committing for fixing what pre-commit can do.