### PR TITLE
add `detect_floater` to Sonde object

### DIFF
--- a/src/halodrops/pipeline.py
+++ b/src/halodrops/pipeline.py
@@ -378,6 +378,7 @@ pipeline = {
         "apply": iterate_Sonde_method_over_dict_of_Sondes_objects,
         "functions": [
             "filter_no_launch_detect",
+            "detect_floater",
             "profile_fullness",
             "near_surface_coverage",
             "filter_qc_fail",
@@ -388,6 +389,7 @@ pipeline = {
         "intake": "sondes",
         "apply": iterate_Sonde_method_over_dict_of_Sondes_objects,
         "functions": [
+            "create_interim_l2_ds",
             "convert_to_si",
             "get_l2_variables",
             "add_compression_and_encoding_properties",

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -299,6 +299,33 @@ class Sonde:
                 )
             return self
 
+    def crop_aspen_ds_to_landing_time(self):
+        """
+        Crops the aspen_ds to the time period before landing.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        self
+            The object itself with the new `cropped_aspen_ds` attribute added if the sonde is a floater.
+        """
+        if hasattr(self, "is_floater"):
+            if self.is_floater:
+                if hasattr(self, "landing_time"):
+                    object.__setattr__(
+                        self,
+                        "cropped_aspen_ds",
+                        self.aspen_ds.sel(time=slice(self.landing_time, None)),
+                    )
+        else:
+            raise ValueError(
+                "The attribute `is_floater` does not exist. Please run `detect_floater` method first."
+            )
+        return self
+
     def profile_fullness(
         self,
         variable_dict={"u_wind": 4, "v_wind": 4, "rh": 2, "tdry": 2, "pres": 2},

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -583,6 +583,30 @@ class Sonde:
 
         return self
 
+    def create_interim_l2_ds(self):
+        """
+        Creates an interim L2 dataset from the aspen_ds or cropped_aspen_ds attribute.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        self : object
+            Returns the sonde object with the interim L2 dataset added as an attribute.
+        """
+        if self.is_floater:
+            if not hasattr(self, "cropped_aspen_ds"):
+                self.crop_aspen_ds_to_landing_time()
+            ds = self.cropped_aspen_ds
+        else:
+            ds = self.aspen_ds
+
+        object.__setattr__(self, "_interim_l2_ds", ds)
+
+        return self
+
     def convert_to_si(self, variables=["rh", "pres", "tdry"], skip=False):
         """
         Converts variables to SI units.
@@ -754,6 +778,7 @@ class Sonde:
             "launch_time_(UTC)": str(self.aspen_ds.launch_time.values)
             if hasattr(self.aspen_ds, "launch_time")
             else str(self.aspen_ds.base_time.values),
+            "is_floater": self.is_floater,
             "sonde_serial_ID": self.serial_id,
             "author": "Geet George",
             "author_email": "g.george@tudelft.nl",

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -778,7 +778,7 @@ class Sonde:
             "launch_time_(UTC)": str(self.aspen_ds.launch_time.values)
             if hasattr(self.aspen_ds, "launch_time")
             else str(self.aspen_ds.base_time.values),
-            "is_floater": self.is_floater,
+            "is_floater": self.is_floater.__str__(),
             "sonde_serial_ID": self.serial_id,
             "author": "Geet George",
             "author_email": "g.george@tudelft.nl",

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -337,6 +337,8 @@ class Sonde:
     ):
         """
         Calculates the profile coverage for a given set of variables, considering their sampling frequency.
+        If the sonde is a floater, the function will take the `cropped_aspen_ds` attribute
+        (calculated with the `crop_aspen_ds_to_landing_time` method) as the dataset to calculate the profile coverage.
 
         This function assumes that the time_dimension coordinates are spaced over 0.25 seconds,
         implying a timestamp_frequency of 4 hertz. This is applicable for ASPEN-processed QC and PQC files,
@@ -380,7 +382,13 @@ class Sonde:
                 fullness_threshold = float(fullness_threshold)
 
             for variable, sampling_frequency in variable_dict.items():
-                dataset = self.aspen_ds[variable]
+                if self.is_floater:
+                    if not hasattr(self, "cropped_aspen_ds"):
+                        self.crop_aspen_ds_to_landing_time()
+                    dataset = self.cropped_aspen_ds[variable]
+                else:
+                    dataset = self.aspen_ds[variable]
+
                 weighed_time_size = len(dataset[time_dimension]) / (
                     timestamp_frequency / sampling_frequency
                 )

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -399,7 +399,7 @@ class Sonde:
         alt_bounds : list, optional
             The lower and upper bounds of altitude in meters to consider for the calculation. Defaults to [0,1000].
         alt_dimension_name : str, optional
-            The name of the altitude dimension. Defaults to "alt".
+            The name of the altitude dimension. Defaults to "alt". If the sonde is a floater, this will be set to "gpsalt" regardless of user-provided value.
         count_threshold : int, optional
             The minimum count of non-null values required for a variable to be considered as having near surface coverage. Defaults to 50.
         add_near_surface_count_attribute : bool, optional
@@ -424,6 +424,14 @@ class Sonde:
                 raise ValueError(
                     "The attribute `aspen_ds` does not exist. Please run `add_aspen_ds` method first."
                 )
+
+            if not hasattr(self, "is_floater"):
+                raise ValueError(
+                    "The attribute `is_floater` does not exist. Please run `detect_floater` method first."
+                )
+
+            if self.is_floater:
+                alt_dimension_name = "gpsalt"
 
             if isinstance(alt_bounds, str):
                 alt_bounds = alt_bounds.split(",")


### PR DESCRIPTION
For HALO-(AC)3, some sondes seem to have landed on ice. For example, 3 sondes in the 5-sonde circle flown close to the pole (last flight of the campaign, 20220412). Therefore, they kept transmitting data from the surface (outside of their design to sink, which they couldn't in this case). This causes problems with QC.

The function added by this commit should detect if the sonde is a floater.

To determine if a sonde is a floater is difficult with an algorithm because "floaters" behave quite differently. I decided to go for a simple check, i.e. if the gpsalt (altitude from gps) and pressure (pres) has not changed (by more than 1 m and 1 hPa, respectively) in a user-decided number of consecutive timesteps (default 3) for measurements at the surface (decided by gpsalt_threshold, default 25m), then the sonde is a floater.

This is not perfect, but it should work for most cases. The function adds an attribute `is_floater`(True/False) and if that is True, it will also add another attribute `landing_time`. The latter attribute will be used to restrict measurements from the sonde to the time before it landed, for QC and for inclusion in to L2 and onwards.