### PR TITLE
read_l2 added

### DIFF
--- a/src/halodrops/pipeline.py
+++ b/src/halodrops/pipeline.py
@@ -406,7 +406,7 @@ pipeline = {
     "read_and_process_L2": {
         "intake": "sondes",
         "apply": iterate_Sonde_method_over_dict_of_Sondes_objects,
-        "functions": [],
+        "functions": ["get_l2_filename", "read_l2"],
         "output": "sondes",
         "comment": "This step reads from the saved L2 files and prepares individual sonde datasets before they can be concatenated to create L3.",
     },

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -912,6 +912,26 @@ class Sonde:
 
         return self
 
+    def read_l2(self, l2_dir: str = None):
+        """
+        Reads the L2 file to the specified directory.
+
+        Parameters
+        ----------
+        l2_dir : str, optional
+            The directory to read the L2 file from. The default is the directory of the A-file with '0' replaced by '2'.
+
+        Returns
+        -------
+        self : object
+            Returns the sonde object with the L2 file read from the specified directory using the l2_filename attribute to get the name.
+        """
+        if l2_dir is None:
+            l2_dir = os.path.dirname(self.afile)[:-1] + "2"
+        ds = xr.open_dataset(os.path.join(l2_dir, self.l2_filename), engine="netcdf4")
+        object.__setattr__(self, "_interim_l3_ds", ds)
+        return self
+
     def add_l2_ds(self, l2_dir: str = None):
         """
         Adds the L2 dataset as an attribute to the sonde object.


### PR DESCRIPTION
function added to read existing l2 dataset. 
I used `open_dataset` instead of the existing `_interim_l2_ds` to make it possible to also start the pipeline there (once I managed to add that functionality to the `run_pipeline`. I don't know if we want that like this. 

The "get_l2_filename" function is added for the same reason: if there is no l1 to l2 processing before it's necessary to have that. If we just go from 1 (or 0) until it breaks, that can be removed. 