### PR TITLE
data path rearrangement

### DIFF
--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -54,7 +54,12 @@ class Flight:
     """
 
     def __init__(
-        self, data_directory, flight_id, platform_id, platform_directory_name=None, path_structure="levels_first",
+        self,
+        data_directory,
+        flight_id,
+        platform_id,
+        platform_directory_name=None,
+        path_structure="levels_first",
     ):
         """Creates an instance of Paths object for a given flight
 
@@ -80,10 +85,10 @@ class Flight:
         `l1dir`
             Path to Level-1 data directory
         """
-        
+
         self.path_structure = path_structure
         self.data_directory = data_directory
-        
+
         if self.path_structure == "flightid_first":
             self.logger = logging.getLogger("halodrops.helper.paths.Paths")
             if platform_directory_name is None:
@@ -95,28 +100,29 @@ class Flight:
             self.platform_id = platform_id
             self.l1dir = os.path.join(self.flight_idpath, "Level_1")
             self.l0dir = os.path.join(self.flight_idpath, "Level_0")
-    
+
             self.logger.info(
                 f"Created Path Instance: {self.flight_idpath=}; {self.flight_id=}; {self.l1dir=}"
             )
-            
+
         elif self.path_structure == "levels_first":
-        
+
             self.logger = logging.getLogger("halodrops.helper.paths.Paths")
             if platform_directory_name is None:
                 platform_directory_name = platform_id
             self.l0dir = os.path.join(
-                data_directory, platform_directory_name, "Level_0", flight_id)
+                data_directory, platform_directory_name, "Level_0", flight_id
+            )
             self.l1dir = os.path.join(
-                data_directory, platform_directory_name, "Level_1", flight_id)
+                data_directory, platform_directory_name, "Level_1", flight_id
+            )
             self.flight_id = flight_id
             self.flight_idpath = None
             self.platform_id = platform_id
-            
+
             self.logger.info(
                 f"Created Path Instance; {self.flight_id=}; {self.l0dir=}; {self.l1dir=}"
             )
-
 
     def get_all_afiles(self):
         """Returns a list of paths to all A-files for the given directory
@@ -137,8 +143,10 @@ class Flight:
             Path to quicklooks directory
         """
         if self.path_structure == "levels_first":
-            quicklooks_path_str = os.path.join(self.data_directory, self.platform_id, "Quicklooks", self.flight_id)
-            
+            quicklooks_path_str = os.path.join(
+                self.data_directory, self.platform_id, "Quicklooks", self.flight_id
+            )
+
         if pp(quicklooks_path_str).exists():
             self.logger.info(f"Path exists: {quicklooks_path_str=}")
         else:

--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -82,6 +82,7 @@ class Flight:
         """
         
         self.path_structure = path_structure
+        self.data_directory = data_directory
         
         if self.path_structure == "flightid_first":
             self.logger = logging.getLogger("halodrops.helper.paths.Paths")
@@ -135,7 +136,9 @@ class Flight:
         `str`
             Path to quicklooks directory
         """
-        quicklooks_path_str = os.path.join(self.flight_idpath, "Quicklooks")
+        if self.path_structure == "levels_first":
+            quicklooks_path_str = os.path.join(self.data_directory, self.platform_id, "Quicklooks")
+            
         if pp(quicklooks_path_str).exists():
             self.logger.info(f"Path exists: {quicklooks_path_str=}")
         else:

--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -109,6 +109,7 @@ class Flight:
             self.l1dir = os.path.join(
                 data_directory, platform_directory_name, "Level_1", flight_id)
             self.flight_id = flight_id
+            self.flight_idpath = None
             self.platform_id = platform_id
             
             self.logger.info(

--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -26,9 +26,10 @@ class Platform:
         self.platform_directory_name = platform_directory_name
         self.data_directory = data_directory
         self.flight_ids = self.get_flight_ids()
+        self.levels = ["Level_0", "Level_1", "Level_2"]
 
     def get_flight_ids(self):
-        """Returns a list of flight IDs for the given platform directory"""
+        """Returns a list of flight IDs for the given platform and level directory"""
         if self.platform_directory_name is None:
             platform_dir = os.path.join(self.data_directory, self.platform_id)
         else:
@@ -37,9 +38,10 @@ class Platform:
             )
 
         flight_ids = []
-        for flight_dir in os.listdir(platform_dir):
-            if os.path.isdir(os.path.join(platform_dir, flight_dir)):
-                flight_ids.append(flight_dir)
+        for level_dir in os.listdir(platform_dir):
+            for flight_dir in os.listdir(os.path.join(platform_dir, level_dir)):
+                if os.path.isdir(os.path.join(platform_dir, level_dir, flight_dir)):
+                    flight_ids.append(flight_dir)
         return flight_ids
 
 
@@ -52,7 +54,7 @@ class Flight:
     """
 
     def __init__(
-        self, data_directory, flight_id, platform_id, platform_directory_name=None
+        self, data_directory, flight_id, platform_id, platform_directory_name=None, path_structure="levels_first",
     ):
         """Creates an instance of Paths object for a given flight
 
@@ -78,20 +80,41 @@ class Flight:
         `l1dir`
             Path to Level-1 data directory
         """
-        self.logger = logging.getLogger("halodrops.helper.paths.Paths")
-        if platform_directory_name is None:
-            platform_directory_name = platform_id
-        self.flight_idpath = os.path.join(
-            data_directory, platform_directory_name, flight_id
-        )
-        self.flight_id = flight_id
-        self.platform_id = platform_id
-        self.l1dir = os.path.join(self.flight_idpath, "Level_1")
-        self.l0dir = os.path.join(self.flight_idpath, "Level_0")
+        
+        self.path_structure = path_structure
+        
+        if self.path_structure == "flightid_first":
+            self.logger = logging.getLogger("halodrops.helper.paths.Paths")
+            if platform_directory_name is None:
+                platform_directory_name = platform_id
+            self.flight_idpath = os.path.join(
+                data_directory, platform_directory_name, flight_id
+            )
+            self.flight_id = flight_id
+            self.platform_id = platform_id
+            self.l1dir = os.path.join(self.flight_idpath, "Level_1")
+            self.l0dir = os.path.join(self.flight_idpath, "Level_0")
+    
+            self.logger.info(
+                f"Created Path Instance: {self.flight_idpath=}; {self.flight_id=}; {self.l1dir=}"
+            )
+            
+        elif self.path_structure == "levels_first":
+        
+            self.logger = logging.getLogger("halodrops.helper.paths.Paths")
+            if platform_directory_name is None:
+                platform_directory_name = platform_id
+            self.l0dir = os.path.join(
+                data_directory, platform_directory_name, "Level_0", flight_id)
+            self.l1dir = os.path.join(
+                data_directory, platform_directory_name, "Level_1", flight_id)
+            self.flight_id = flight_id
+            self.platform_id = platform_id
+            
+            self.logger.info(
+                f"Created Path Instance; {self.flight_id=}; {self.l0dir=}; {self.l1dir=}"
+            )
 
-        self.logger.info(
-            f"Created Path Instance: {self.flight_idpath=}; {self.flight_id=}; {self.l1dir=}"
-        )
 
     def get_all_afiles(self):
         """Returns a list of paths to all A-files for the given directory
@@ -133,12 +156,13 @@ class Flight:
             launch_detect = rr.check_launch_detect_in_afile(a_file)
             sonde_id = rr.get_sonde_id(a_file)
             launch_time = rr.get_launch_time(a_file)
-
             Sondes[sonde_id] = Sonde(sonde_id, launch_time=launch_time)
             Sondes[sonde_id].add_launch_detect(launch_detect)
             Sondes[sonde_id].add_flight_id(self.flight_id)
+            Sondes[sonde_id].add_path_structure(self.path_structure)
             Sondes[sonde_id].add_platform_id(self.platform_id)
             Sondes[sonde_id].add_afile(a_file)
+
             if launch_detect:
                 Sondes[sonde_id].add_postaspenfile()
                 Sondes[sonde_id].add_aspen_ds()

--- a/src/halodrops/helper/paths.py
+++ b/src/halodrops/helper/paths.py
@@ -137,7 +137,7 @@ class Flight:
             Path to quicklooks directory
         """
         if self.path_structure == "levels_first":
-            quicklooks_path_str = os.path.join(self.data_directory, self.platform_id, "Quicklooks")
+            quicklooks_path_str = os.path.join(self.data_directory, self.platform_id, "Quicklooks", self.flight_id)
             
         if pp(quicklooks_path_str).exists():
             self.logger.info(f"Path exists: {quicklooks_path_str=}")

--- a/src/halodrops/pipeline.py
+++ b/src/halodrops/pipeline.py
@@ -225,7 +225,7 @@ def create_and_populate_flight_object(
                     platform,
                     platform_objects[platform].platform_directory_name,
                 )
-                
+
                 output["sondes"].update(flight.populate_sonde_instances())
     return output["platforms"], output["sondes"]
 

--- a/src/halodrops/pipeline.py
+++ b/src/halodrops/pipeline.py
@@ -217,14 +217,16 @@ def create_and_populate_flight_object(
     output["platforms"] = platform_objects
     output["sondes"] = {}
     for platform in platform_objects:
-        for flight_id in platform_objects[platform].flight_ids:
-            flight = Flight(
-                platform_objects[platform].data_directory,
-                flight_id,
-                platform,
-                platform_objects[platform].platform_directory_name,
-            )
-            output["sondes"].update(flight.populate_sonde_instances())
+        for level in platform_objects[platform].levels:
+            for flight_id in platform_objects[platform].flight_ids:
+                flight = Flight(
+                    platform_objects[platform].data_directory,
+                    flight_id,
+                    platform,
+                    platform_objects[platform].platform_directory_name,
+                )
+                
+                output["sondes"].update(flight.populate_sonde_instances())
     return output["platforms"], output["sondes"]
 
 

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -56,6 +56,7 @@ class Sonde:
             if the user specifies path_structure="flightid_first".
         """
         object.__setattr__(self, "path_structure", path_structure)
+        return self
 
 
     def add_flight_id(self, flight_id: str) -> None:

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -155,7 +155,6 @@ class Sonde:
                 
                 if self.path_structure == "levels_first":
                     path_to_l1dir = os.path.dirname(self.afile).replace("Level_0", "Level_1")
-                    print(path_to_l1dir)
                     postaspenfile = (
                         "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
                     )
@@ -199,7 +198,6 @@ class Sonde:
         If the `postaspenfile` attribute doesn't exist, function will print out an error
         """
         
-        print(self.postaspenfile)
         if hasattr(self, "postaspenfile"):
             ds = xr.open_dataset(self.postaspenfile)
             if "SondeId" not in ds.attrs:
@@ -948,7 +946,6 @@ class Sonde:
                 l2_dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
             elif self.path_structure == "flightid_first":
                 l2_dir = os.path.dirname(self.afile)[:-1] + "2"
-            print("L2", l2_dir)
 
         if not os.path.exists(l2_dir):
             os.makedirs(l2_dir)

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -927,13 +927,13 @@ class Sonde:
 
         return self
 
-    def write_l2(self, l2dir: str = None):
+    def write_l2(self, l2_dir: str = None):
         """
         Writes the L2 file to the specified directory.
 
         Parameters
         ----------
-        l2dir : str, optional
+        l2_dir : str, optional
             The directory to write the L2 file to. The default is the directory of the A-file with '0' replaced by '2'.
     
         Returns
@@ -942,28 +942,28 @@ class Sonde:
             Returns the sonde object with the L2 file written to the specified directory using the l2_filename attribute to set the name.
         """
 
-        if l2dir is None:
+        if l2_dir is None:
             
             if self.path_structure == "levels_first":
-                l2dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
+                l2_dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
             elif self.path_structure == "flightid_first":
-                l2dir = os.path.dirname(self.afile)[:-1] + "2"
-            print("L2", l2dir)
+                l2_dir = os.path.dirname(self.afile)[:-1] + "2"
+            print("L2", l2_dir)
 
-        if not os.path.exists(l2dir):
-            os.makedirs(l2dir)
+        if not os.path.exists(l2_dir):
+            os.makedirs(l2_dir)
 
-        self._interim_l2_ds.to_netcdf(os.path.join(l2dir, self.l2_filename))
+        self._interim_l2_ds.to_netcdf(os.path.join(l2_dir, self.l2_filename))
 
         return self
 
-    def add_l2_ds(self, l2dir: str = None):
+    def add_l2_ds(self, l2_dir: str = None):
         """
         Adds the L2 dataset as an attribute to the sonde object.
 
         Parameters
         ----------
-        l2dir : str, optional
+        l2_dir : str, optional
             The directory to read the L2 file from. The default is the directory of the A-file with '0' replaced by '2'.
 
         Returns
@@ -971,14 +971,14 @@ class Sonde:
         self : object
             Returns the sonde object with the L2 dataset added as an attribute.
         """
-        if l2dir is None:
+        if l2_dir is None:
             if self.path_structure == "levels_first":
-                l2dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
+                l2_dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
             elif self.path_structure == "flightid_first":
-                l2dir = os.path.dirname(self.afile)[:-1] + "2"
+                l2_dir = os.path.dirname(self.afile)[:-1] + "2"
 
         object.__setattr__(
-            self, "l2_ds", xr.open_dataset(os.path.join(l2dir, self.l2_filename))
+            self, "l2_ds", xr.open_dataset(os.path.join(l2_dir, self.l2_filename))
         )
 
         return self

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -43,6 +43,20 @@ class Sonde:
         object.__setattr__(self, "qc", type("", (), {})())
         if self.launch_time is not None:
             object.__setattr__(self, "sort_index", self.launch_time)
+        
+        
+    def add_path_structure(self, path_structure="levels_first"):
+        
+        """ Sets attribute of file structure
+        Parameters:
+        ----------
+        path_structure : str, optional
+            The structure of the paths to store data. Default is to have "/pathtodata/Level_#/flight_id". 
+            But to be backwards compatible it is possible to use the old structure of "/pathtodata/flight_id/Level_#"
+            if the user specifies path_structure="flightid_first".
+        """
+        object.__setattr__(self, "path_structure", path_structure)
+
 
     def add_flight_id(self, flight_id: str) -> None:
         """Sets attribute of flight ID
@@ -137,10 +151,19 @@ class Sonde:
 
         if path_to_postaspenfile is None:
             if hasattr(self, "afile"):
-                path_to_l1dir = os.path.dirname(self.afile)[:-1] + "1"
-                postaspenfile = (
-                    "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
-                )
+                
+                if self.path_structure == "levels_first":
+                    path_to_l1dir = os.path.dirname(self.afile).replace("Level_0", "Level_1")
+                    print(path_to_l1dir)
+                    postaspenfile = (
+                        "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
+                    )
+                elif self.path_structure == "flightid_first":
+                    path_to_l1dir = os.path.dirname(self.afile)[:-1] + "1"
+                    postaspenfile = (
+                        "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
+                    )
+                    
                 path_to_postaspenfile = os.path.join(path_to_l1dir, postaspenfile)
                 if os.path.exists(path_to_postaspenfile):
                     object.__setattr__(self, "postaspenfile", path_to_postaspenfile)
@@ -165,6 +188,7 @@ class Sonde:
                 )
         return self
 
+
     def add_aspen_ds(self) -> None:
         """Sets attribute with an xarray Dataset read from post-ASPEN file
 
@@ -173,7 +197,8 @@ class Sonde:
 
         If the `postaspenfile` attribute doesn't exist, function will print out an error
         """
-
+        
+        print(self.postaspenfile)
         if hasattr(self, "postaspenfile"):
             ds = xr.open_dataset(self.postaspenfile)
             if "SondeId" not in ds.attrs:
@@ -901,38 +926,43 @@ class Sonde:
 
         return self
 
-    def write_l2(self, l2_dir: str = None):
+    def write_l2(self, l2dir: str = None):
         """
         Writes the L2 file to the specified directory.
 
         Parameters
         ----------
-        l2_dir : str, optional
+        l2dir : str, optional
             The directory to write the L2 file to. The default is the directory of the A-file with '0' replaced by '2'.
-
+    
         Returns
         -------
         self : object
             Returns the sonde object with the L2 file written to the specified directory using the l2_filename attribute to set the name.
         """
 
-        if l2_dir is None:
-            l2_dir = os.path.dirname(self.afile)[:-1] + "2"
+        if l2dir is None:
+            
+            if self.path_structure == "levels_first":
+                l2dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
+            elif self.path_structure == "flightid_first":
+                l2dir = os.path.dirname(self.afile)[:-1] + "2"
+            print("L2", l2dir)
 
-        if not os.path.exists(l2_dir):
-            os.makedirs(l2_dir)
+        if not os.path.exists(l2dir):
+            os.makedirs(l2dir)
 
-        self._interim_l2_ds.to_netcdf(os.path.join(l2_dir, self.l2_filename))
+        self._interim_l2_ds.to_netcdf(os.path.join(l2dir, self.l2_filename))
 
         return self
 
-    def add_l2_ds(self, l2_dir: str = None):
+    def add_l2_ds(self, l2dir: str = None):
         """
         Adds the L2 dataset as an attribute to the sonde object.
 
         Parameters
         ----------
-        l2_dir : str, optional
+        l2dir : str, optional
             The directory to read the L2 file from. The default is the directory of the A-file with '0' replaced by '2'.
 
         Returns
@@ -940,11 +970,14 @@ class Sonde:
         self : object
             Returns the sonde object with the L2 dataset added as an attribute.
         """
-        if l2_dir is None:
-            l2_dir = os.path.dirname(self.afile)[:-1] + "2"
+        if l2dir is None:
+            if self.path_structure == "levels_first":
+                l2dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
+            elif self.path_structure == "flightid_first":
+                l2dir = os.path.dirname(self.afile)[:-1] + "2"
 
         object.__setattr__(
-            self, "l2_ds", xr.open_dataset(os.path.join(l2_dir, self.l2_filename))
+            self, "l2_ds", xr.open_dataset(os.path.join(l2dir, self.l2_filename))
         )
 
         return self

--- a/src/halodrops/processor.py
+++ b/src/halodrops/processor.py
@@ -43,21 +43,19 @@ class Sonde:
         object.__setattr__(self, "qc", type("", (), {})())
         if self.launch_time is not None:
             object.__setattr__(self, "sort_index", self.launch_time)
-        
-        
+
     def add_path_structure(self, path_structure="levels_first"):
-        
-        """ Sets attribute of file structure
+
+        """Sets attribute of file structure
         Parameters:
         ----------
         path_structure : str, optional
-            The structure of the paths to store data. Default is to have "/pathtodata/Level_#/flight_id". 
+            The structure of the paths to store data. Default is to have "/pathtodata/Level_#/flight_id".
             But to be backwards compatible it is possible to use the old structure of "/pathtodata/flight_id/Level_#"
             if the user specifies path_structure="flightid_first".
         """
         object.__setattr__(self, "path_structure", path_structure)
         return self
-
 
     def add_flight_id(self, flight_id: str) -> None:
         """Sets attribute of flight ID
@@ -152,9 +150,11 @@ class Sonde:
 
         if path_to_postaspenfile is None:
             if hasattr(self, "afile"):
-                
+
                 if self.path_structure == "levels_first":
-                    path_to_l1dir = os.path.dirname(self.afile).replace("Level_0", "Level_1")
+                    path_to_l1dir = os.path.dirname(self.afile).replace(
+                        "Level_0", "Level_1"
+                    )
                     postaspenfile = (
                         "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
                     )
@@ -163,7 +163,7 @@ class Sonde:
                     postaspenfile = (
                         "D" + os.path.basename(self.afile).split(".")[0][1:] + "QC.nc"
                     )
-                    
+
                 path_to_postaspenfile = os.path.join(path_to_l1dir, postaspenfile)
                 if os.path.exists(path_to_postaspenfile):
                     object.__setattr__(self, "postaspenfile", path_to_postaspenfile)
@@ -188,7 +188,6 @@ class Sonde:
                 )
         return self
 
-
     def add_aspen_ds(self) -> None:
         """Sets attribute with an xarray Dataset read from post-ASPEN file
 
@@ -197,7 +196,7 @@ class Sonde:
 
         If the `postaspenfile` attribute doesn't exist, function will print out an error
         """
-        
+
         if hasattr(self, "postaspenfile"):
             ds = xr.open_dataset(self.postaspenfile)
             if "SondeId" not in ds.attrs:
@@ -933,7 +932,7 @@ class Sonde:
         ----------
         l2_dir : str, optional
             The directory to write the L2 file to. The default is the directory of the A-file with '0' replaced by '2'.
-    
+
         Returns
         -------
         self : object
@@ -941,7 +940,7 @@ class Sonde:
         """
 
         if l2_dir is None:
-            
+
             if self.path_structure == "levels_first":
                 l2_dir = os.path.dirname(self.afile).replace("Level_0", "Level_2")
             elif self.path_structure == "flightid_first":

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -4,7 +4,13 @@ import os
 main_data_directory = "../sample"
 platform = "HALO"
 flightdate = "20200101"
-l1_path = os.path.join(main_data_directory, platform, flightdate, "Level_1")
+path_structure = "levels_first"
+
+if path_structure == "levels_first":
+    l1_path = os.path.join(main_data_directory, platform, "Level_1", flightdate)
+if path_structure == "flightid_first":
+    l1_path = os.path.join(main_data_directory, platform, flightdate, "Level_1")
+    
 quicklooks_path = os.path.join(main_data_directory, platform, flightdate, "Quicklooks")
 
 object = paths.Flight(main_data_directory, flightdate, platform)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,14 +8,18 @@ path_structure = "levels_first"
 
 if path_structure == "levels_first":
     l1_path = os.path.join(main_data_directory, platform, "Level_1", flightdate)
-    quicklooks_path = os.path.join(main_data_directory, platform, "Quicklooks", flightdate)
+    quicklooks_path = os.path.join(
+        main_data_directory, platform, "Quicklooks", flightdate
+    )
     print(quicklooks_path)
 
 if path_structure == "flightid_first":
     l1_path = os.path.join(main_data_directory, platform, flightdate, "Level_1")
-    quicklooks_path = os.path.join(main_data_directory, platform, flightdate, "Quicklooks")
+    quicklooks_path = os.path.join(
+        main_data_directory, platform, flightdate, "Quicklooks"
+    )
 
-    
+
 object = paths.Flight(main_data_directory, flightdate, platform)
 
 print(object.quicklooks_path())

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -3,12 +3,13 @@ import os
 
 main_data_directory = "../sample"
 platform = "HALO"
-flightdate = "20200101"
+flightdate = "20200201"
 path_structure = "levels_first"
 
 if path_structure == "levels_first":
     l1_path = os.path.join(main_data_directory, platform, "Level_1", flightdate)
-    quicklooks_path = os.path.join(main_data_directory, platform, "Quicklooks")
+    quicklooks_path = os.path.join(main_data_directory, platform, "Quicklooks", flightdate)
+    print(quicklooks_path)
 
 if path_structure == "flightid_first":
     l1_path = os.path.join(main_data_directory, platform, flightdate, "Level_1")
@@ -16,6 +17,8 @@ if path_structure == "flightid_first":
 
     
 object = paths.Flight(main_data_directory, flightdate, platform)
+
+print(object.quicklooks_path())
 
 
 def test_l1_path():

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,11 +8,13 @@ path_structure = "levels_first"
 
 if path_structure == "levels_first":
     l1_path = os.path.join(main_data_directory, platform, "Level_1", flightdate)
+    quicklooks_path = os.path.join(main_data_directory, platform, "Quicklooks")
+
 if path_structure == "flightid_first":
     l1_path = os.path.join(main_data_directory, platform, flightdate, "Level_1")
-    
-quicklooks_path = os.path.join(main_data_directory, platform, flightdate, "Quicklooks")
+    quicklooks_path = os.path.join(main_data_directory, platform, flightdate, "Quicklooks")
 
+    
 object = paths.Flight(main_data_directory, flightdate, platform)
 
 

--- a/tests/test_sonde.py
+++ b/tests/test_sonde.py
@@ -93,6 +93,7 @@ def test_sonde_add_postaspenfile_without_launch(temp_afile_nolaunchdetected):
     """
     sonde = Sonde(serial_id=s_id)
     sonde.add_afile(temp_afile_nolaunchdetected)
+    sonde.add_path_structure()
     with pytest.raises(ValueError):
         sonde.add_postaspenfile()
 
@@ -105,6 +106,7 @@ def test_sonde_add_postaspenfile_with_only_afile(
     """
     sonde = Sonde(serial_id=s_id)
     sonde.add_afile(temp_afile_launchdetected)
+    sonde.add_path_structure()
     sonde.add_postaspenfile()
     assert sonde.postaspenfile == temp_postaspenfile
 


### PR DESCRIPTION
I changed the path reading code to the new data structure suggestion: "/pathtodata/platform/level/flight_id/". It is not super clean but it works. At two points in the code (in "paths.py" and in "processor.py", a parameter `path_structure` needs to be specified (and is by default "levels_first" which adopts the new folder structure) which is not ideal. Probably there is a better way to do it but this works for now. 